### PR TITLE
Allowed full data set to be used in functions

### DIFF
--- a/golem/core/test_case.py
+++ b/golem/core/test_case.py
@@ -200,7 +200,7 @@ def format_parameters(step, root_path, project, stored_keys):
             elif 'random(' in parameter:
                 this_parameter_string = parameter
             else:
-                is_data_var = 'data.' in parameter
+                is_data_var = 'data.' in parameter or 'data' in parameter
 
                 is_in_stored_keys = parameter in stored_keys
                 action_is_store = action == 'store'


### PR DESCRIPTION
We've got a pretty complex test that is much easier if you have access to the full data set in pages.

Is there a way to access the data set in pages files? 
This pull request stops data being converted to a string when used in a pages function, not sure if its the best way to accomplish this.

Thanks,
-Daniel