### PR TITLE
added verify to http_get and http_post for disabling SSL errors

### DIFF
--- a/golem/actions.py
+++ b/golem/actions.py
@@ -130,6 +130,10 @@ def debug():
         pass
 
 
+def pdb_debug():
+    import pdb
+    pdb.set_trace()
+
 def get(url):
     navigate(url)
 

--- a/golem/actions.py
+++ b/golem/actions.py
@@ -513,19 +513,19 @@ def wait_for_element_visible(element, timeout=20):
             timed_out = True
 
 
-def http_get(url, headers={}, params={}):
+def http_get(url, verify_ssl_cert, headers={}, params={}):
     step_message = 'Make GET request to {}'.format(url)
     execution.logger.info(step_message)
     _capture_or_add_step(step_message, False)
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, verify=verify_ssl_cert)
     store('last_response', response)
 
 
-def http_post(url, headers={}, data={}):
+def http_post(url, verify_ssl_cert, headers={}, data={}):
     step_message = 'Make POST request to {}'.format(url)
     execution.logger.info(step_message)
     _capture_or_add_step(step_message, False)
-    response = requests.post(url, headers=headers, data=data)
+    response = requests.post(url, headers=headers, data=data, verify=verify_ssl_cert)
     store('last_response', response)
 
 

--- a/golem/actions.py
+++ b/golem/actions.py
@@ -130,10 +130,6 @@ def debug():
         pass
 
 
-def pdb_debug():
-    import pdb
-    pdb.set_trace()
-
 def get(url):
     navigate(url)
 
@@ -517,7 +513,7 @@ def wait_for_element_visible(element, timeout=20):
             timed_out = True
 
 
-def http_get(url, verify_ssl_cert, headers={}, params={}):
+def http_get(url, headers={}, params={}, verify_ssl_cert=True):
     step_message = 'Make GET request to {}'.format(url)
     execution.logger.info(step_message)
     _capture_or_add_step(step_message, False)
@@ -525,7 +521,7 @@ def http_get(url, verify_ssl_cert, headers={}, params={}):
     store('last_response', response)
 
 
-def http_post(url, verify_ssl_cert, headers={}, data={}):
+def http_post(url, headers={}, data={}, verify_ssl_cert=True):
     step_message = 'Make POST request to {}'.format(url)
     execution.logger.info(step_message)
     _capture_or_add_step(step_message, False)

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -114,13 +114,15 @@ def get_global_actions():
             'name': 'http_get',
             'parameters': [{'name': 'url', 'type': 'value'},
                            {'name': 'headers', 'type': 'multiline-value'},
-                           {'name': 'params', 'type': 'value'}]
+                           {'name': 'params', 'type': 'value'},
+                           {'name': 'verify SSL certificate', 'type': 'value'}]
         },
         {
             'name': 'http_post',
             'parameters': [{'name': 'url', 'type': 'value'},
                            {'name': 'headers', 'type': 'value'},
-                           {'name': 'data', 'type': 'value'}]
+                           {'name': 'data', 'type': 'value'},
+                           {'name': 'verify SSL certificate', 'type': 'value'}]
         },
         {
             'name': 'navigate',

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -107,6 +107,10 @@ def get_global_actions():
             'parameters': []
         },
         {
+            'name': 'pdb_debug',
+            'parameters': []
+        },
+        {
             'name': 'get',
             'parameters': [{'name': 'url', 'type': 'value'}]
         },

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -107,10 +107,6 @@ def get_global_actions():
             'parameters': []
         },
         {
-            'name': 'pdb_debug',
-            'parameters': []
-        },
-        {
             'name': 'get',
             'parameters': [{'name': 'url', 'type': 'value'}]
         },

--- a/golem/test_runner/start_execution.py
+++ b/golem/test_runner/start_execution.py
@@ -7,7 +7,7 @@ from golem.core import (test_execution,
                         report,
                         environment_manager,
                         settings_manager)
-from golem.test_runner.multiprocess_executor import multiprocess_executor
+from golem.test_runner.multiprocess_executor import multiprocess_executor, run_test
 from golem.gui import gui_utils
 
 


### PR DESCRIPTION
Tested with an invalid SSL Cert..

setting to True will throw this error
raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=443): Max retries exceeded with url: /login (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:777)'),))

Setting to False will work correctly. 
