### PR TITLE
Update start_execution.py

### DIFF
--- a/golem/test_runner/start_execution.py
+++ b/golem/test_runner/start_execution.py
@@ -7,7 +7,7 @@ from golem.core import (test_execution,
                         report,
                         environment_manager,
                         settings_manager)
-from golem.test_runner.multiprocess_executor import multiprocess_executor
+from golem.test_runner.multiprocess_executor import multiprocess_executor, run_test
 from golem.gui import gui_utils
 
 


### PR DESCRIPTION
run_test missing from imports, causes interactive mode to fail. #60 