### PR TITLE
Feature/golem script

### DIFF
--- a/golem/bin/golem_init.py
+++ b/golem/bin/golem_init.py
@@ -1,9 +1,36 @@
 """A CLI script to start golem from any location
 """
 import os
+import sys
+import subprocess
 
 from golem.main import execute_from_command_line
 
 
 def main():
-    execute_from_command_line(os.getcwd())
+    # Starting the gui using the console script: 'golem gui'
+    # won't work in windows there is a bug in windows when
+    # starting the flask app from a console script
+    # (setup.py, console_scripts) check out
+    # https://github.com/pallets/werkzeug/issues/1136
+    #
+    # In the meantime, for windows, ensure that the 'golem_start.py'
+    # file is present otherwise create it first and use it to
+    # kickstart golem.
+    # TODO
+    if os.name == 'nt':
+        path = os.path.join(os.getcwd(), 'golem_start.py') 
+        if not os.path.isfile(path):
+            golem_start_py_content = ("import os\n\n"
+                                      "from golem.main import execute_from_command_line"
+                                      "\n\n"
+                                      "if __name__ == '__main__':\n"
+                                      "    execute_from_command_line(os.getcwd())\n")
+            with open(path, 'w') as golem_start_file:
+                golem_start_file.write(golem_start_py_content)
+
+        del sys.argv[0]
+        cmd_list = ['python', 'golem_start.py'] + sys.argv
+        subprocess.call(cmd_list)
+    else:
+        execute_from_command_line(os.getcwd())

--- a/golem/bin/golem_init.py
+++ b/golem/bin/golem_init.py
@@ -1,0 +1,9 @@
+"""A CLI script to start golem from any location
+"""
+import os
+
+from golem.main import execute_from_command_line
+
+
+def main():
+    execute_from_command_line(os.getcwd())

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -322,26 +322,15 @@ def create_test_dir(workspace):
     create_new_directory(path_list=[workspace, 'projects'], add_init=True)
     create_new_directory(path_list=[workspace, 'drivers'], add_init=False)
 
-    # copy drivers from golem/bin/drivers to test_dir/drivers
-    pkgdir = sys.modules['golem'].__path__[0]
-    #sourcepath = os.path.join(pkgdir, 'bin', 'drivers')
-    #destination_path = os.path.join(workspace, 'drivers')
-    #shutil.copytree(sourcepath, destination_path)
-
-    golem_py_content = ("import os\n"
-                        "import sys\n"
-                        "\n\n"
-                        "# deactivate .pyc extention file generation\n"
-                        "sys.dont_write_bytecode = True\n"
-                        "\n\n"
-                        "if __name__ == '__main__':\n"
-                        "    del sys.path[0]\n"
-                        "    sys.path.append('')\n\n"
-                        "    from golem.main import execute_from_command_line\n\n"
-                        "    execute_from_command_line(os.getcwd())\n")
-    golem_py_path = os.path.join(workspace, 'golem.py')
-    with open(golem_py_path, 'a') as golem_py_file:
-        golem_py_file.write(golem_py_content)
+    golem_start_py_content = ("import os\n"
+                              "import sys\n\n"
+                              "from golem.main import execute_from_command_line"
+                              "\n\n"
+                              "if __name__ == '__main__':\n"
+                              "    execute_from_command_line(os.getcwd())\n")
+    golem_start_py_path = os.path.join(workspace, 'golem_start.py')
+    with open(golem_start_py_path, 'a') as golem_start_py_file:
+        golem_start_py_file.write(golem_start_py_content)
 
     settings_path = os.path.join(workspace, 'settings.json')
     with open(settings_path, 'a') as settings_file:

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -322,8 +322,7 @@ def create_test_dir(workspace):
     create_new_directory(path_list=[workspace, 'projects'], add_init=True)
     create_new_directory(path_list=[workspace, 'drivers'], add_init=False)
 
-    golem_start_py_content = ("import os\n"
-                              "import sys\n\n"
+    golem_start_py_content = ("import os\n\n"
                               "from golem.main import execute_from_command_line"
                               "\n\n"
                               "if __name__ == '__main__':\n"

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -7,7 +7,7 @@ import golem.actions
 from golem.core import utils
 
 
-def run_test_case(project, test_case_name):
+def run_test_case(project, test_case_name, environment):
     timestamp = utils.get_timestamp()
     param_list = ['golem','run', project, test_case_name,
                   '--timestamp', timestamp]

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -7,11 +7,9 @@ import golem.actions
 from golem.core import utils
 
 
-def run_test_case(project, test_case_name, environment):
+def run_test_case(project, test_case_name):
     timestamp = utils.get_timestamp()
-    param_list = ['python', 'golem.py','run',
-                  project,
-                  test_case_name,
+    param_list = ['golem','run', project, test_case_name,
                   '--timestamp', timestamp]
     if environment:
         param_list.append('--environments')
@@ -22,7 +20,8 @@ def run_test_case(project, test_case_name, environment):
 
 def run_suite(project, suite_name):
     timestamp = utils.get_timestamp()
-    subprocess.Popen(['python', 'golem.py', 'run', project, suite_name, '--timestamp', timestamp])
+    subprocess.Popen(['golem', 'run', project, suite_name,
+                      '--timestamp', timestamp])
     return timestamp
 
 

--- a/golem/main.py
+++ b/golem/main.py
@@ -23,7 +23,7 @@ def execute_from_command_line(root_path):
 
     # set test_execution values
     test_execution.root_path = root_path
-    test_execution.settings = get_global_settings()
+    test_execution.settings = get_global_settings(root_path)
 
     import golem.core
     golem.core.temp = test_execution.settings

--- a/golem/main.py
+++ b/golem/main.py
@@ -1,4 +1,5 @@
 """Main point of entrance to the application"""
+import sys
 
 import argparse
 from .core import test_execution
@@ -7,6 +8,10 @@ from . import commands
 
 
 def execute_from_command_line(root_path):
+    # deactivate .pyc extention file generation
+    sys.dont_write_bytecode = True
+    sys.path.insert(0, '')
+
     parser = argparse.ArgumentParser(
         description='run test case, test suite or start the Golem GUI tool',
         usage='golem.py run project test_case|test_suite|directory',
@@ -18,7 +23,7 @@ def execute_from_command_line(root_path):
 
     # set test_execution values
     test_execution.root_path = root_path
-    test_execution.settings = get_global_settings(root_path)
+    test_execution.settings = get_global_settings()
 
     import golem.core
     golem.core.temp = test_execution.settings

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,10 @@ setup(
                       ],
     tests_require=['pytest'],
     entry_points={
-        'console_scripts': ['golem-admin = golem.bin.golem_admin:main']
+        'console_scripts': [
+            'golem-admin = golem.bin.golem_admin:main',
+            'golem = golem.bin.golem_init:main'
+        ]
     },
     cmdclass={'test': PyTest},
     include_package_data=True,


### PR DESCRIPTION
implement setup.py console_script to start golem, use command 'golem' instead of 'python golem.py'.
'golem.py' changed to 'golem_start.py', it is not needed for macOS or Linux. It can be safely be removed from existing projects.