### PR TITLE
Fix invalid link in Browser Web Drivers docs

### DIFF
--- a/docs/source/browser-web-drivers.md
+++ b/docs/source/browser-web-drivers.md
@@ -59,4 +59,4 @@ iedriver_path": "./drivers/iedriver.exe",
 
 <br>
 
-Next, go to [Interactive Mode](interactive-mode.html)
+Next, go to [Interactive Mode](Interactive-mode.html)


### PR DESCRIPTION
The link to the next page “Interactive Mode” was misspelled causing you to end up on a 404 page if you try to follow along the introduction.