### PR TITLE
FIX

### DIFF
--- a/golem/actions.py
+++ b/golem/actions.py
@@ -868,7 +868,7 @@ def wait_for_element_enabled(element, timeout=20):
     timed_out = False
     #webelement = None
     #try:
-    webelement = browser.get_browser().find(element, timeout)
+    webelement = browser.get_browser().find(element, timeout=timeout)
     enabled = webelement.is_enabled()
     while not enabled and not timed_out:
         execution.logger.debug('Element is not enabled, waiting..')


### PR DESCRIPTION
FIX for action "wait_for_element_enabled": Added timeout keyword argument in order to work with the recently introduced extended driver class

without this fix "raise IncorrectSelectorType('Selector is not a valid option')" is raised when using this action